### PR TITLE
Alternative interface for Coordinate class

### DIFF
--- a/br/edu/metrocamp/chess/piece/Coordinate.java
+++ b/br/edu/metrocamp/chess/piece/Coordinate.java
@@ -27,23 +27,33 @@ public class Coordinate
 		y = -1;
 	}
 	
-	public int getCoord_x()
+	public int x()
 	{
 		return x;
 	}
 	
-	public int getCoord_y()
+	public int y()
 	{
 		return y;
 	}
 	
-	public void setCoord_x(int x)
+	public void set(int x, int y)
 	{
 		this.x = x;
-	}
-	
-	public void setCoord_y(int y)
-	{
 		this.y = y;
+	}
+
+	public String toString() 
+	{
+		return String.valueOf((char) ('a' + x)) + y;
+	}
+
+	public static void main(String[] args) 
+	{
+		Coordinate c = new Coordinate(0, 0);
+		assert c.toString().equals("a0");
+		c.set(3, 7);
+		assert c.toString().equals("d7");
+		System.out.println("c = "+c);
 	}
 }


### PR DESCRIPTION
Hi there!

Follows an alternative interface to the Coordinate class. I think CamelCase doesn't mix well with underscores, so I would prefer `getCoordX()` over `getCoord_x()`, or simple `x()` -- but of course this is a matter of taste.

Usually a simpler interface is the best to choice for use and maintanance. So `setCoord_x()` and `setCoord_y()` could become a single method. If someone is willing to change only a single coordinate them `c.setCoord(c.x(), 7)` could be used.

A `toString()` method could be handy for tests:
- create a empty board
- create a piece
- move the piece
- check that `piece.getCoord().toString()` matches the expected value.
